### PR TITLE
Add systemd service file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,12 +7,45 @@ EXTRA_DIST = $(doc_DATA) vhostmd.init vhostmd.spec autogen.sh
 
 AUTOMAKE_OPTIONS=dist-bzip2
 
-install-data-local:
+install-data-local: install-init-systemv install-init-systemd
 	$(mkinstalldirs) $(DESTDIR)/etc/vhostmd
 	$(mkinstalldirs) $(DESTDIR)/etc/init.d
 	$(mkinstalldirs) $(DESTDIR)/usr/sbin
 	-@INSTALL@ -m 0644 $(srcdir)/vhostmd.xml $(DESTDIR)/etc/vhostmd/vhostmd.conf
 	-@INSTALL@ -m 0644 $(srcdir)/vhostmd.dtd $(DESTDIR)/etc/vhostmd
 	-@INSTALL@ -m 0644 $(srcdir)/metric.dtd $(DESTDIR)/etc/vhostmd
+
+uninstall-local: uninstall-init-systemv uninstall-init-systemd
+	rm -f $(DESTDIR)/etc/vhostmd/vhostmd.conf
+	rm -f $(DESTDIR)/etc/vhostmd/vhostmd.dtd
+	rm -f $(DESTDIR)/etc/vhostmd/metric.dtd
+	rmdir $(DESTDIR)/etc/vhostmd || :
+	rmdir $(DESTDIR)/etc/init.d || :
+	rmdir $(DESTDIR)/usr/sbin || :
+
+if INIT_SCRIPT_SYSTEMV
+install-init-systemv: $(srcdir)/vhostmd.init
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/init.d
 	-@INSTALL@ -m 0755 $(srcdir)/vhostmd.init $(DESTDIR)/etc/init.d/vhostmd
 
+uninstall-init-systemv:
+	rm -f $(DESTDIR)$(sysconfdir)/init.d/vhostmd
+	rmdir $(DESTDIR)$(sysconfdir)/init.d || :
+else ! INIT_SCRIPT_SYSTEMV
+install-init-systemv:
+uninstall-init-systemv:
+endif ! INIT_SCRIPT_SYSTEMV
+
+if INIT_SCRIPT_SYSTEMD
+SYSTEMD_UNIT_DIR = $(prefix)/lib/systemd/system
+install-init-systemd: $(srcdir)/vhostmd.service
+	$(MKDIR_P) $(DESTDIR)$(SYSTEMD_UNIT_DIR)
+	-@INSTALL@ -m 0644 $(srcdir)/vhostmd.service $(DESTDIR)$(SYSTEMD_UNIT_DIR)/vhostmd.service
+
+uninstall-init-systemd:
+	rm -f $(DESTDIR)$(sysconfdir)$(SYSTEMD_UNIT_DIR)/vhostmd.service
+	rmdir $(DESTDIR)$(SYSTEMD_UNIT_DIR) || :
+else ! INIT_SCRIPT_SYSTEMD
+install-init-systemd:
+uninstall-init-systemd:
+endif ! INIT_SCRIPT_SYSTEMD

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,28 @@ AC_ARG_WITH([xenstore],
   esac],[AC_CHECK_HEADER(xs.h, with_xenstore=true)])
 AM_CONDITIONAL(WITH_XENSTORE, test x$with_xenstore = xtrue)
 
+# Configure argument to support type of init system
+AC_ARG_WITH([init_script],
+  [AS_HELP_STRING([--with-init-script],
+    [Type of init script to install: systemv, systemd, check @<:@default=check@:>@])],
+  [],
+  [with_init_script=check])
+init_systemv=no
+init_systemd=no
+if test "$with_init_script" = check && type systemctl >/dev/null 2>&1; then
+   init_systemd=yes
+else
+   init_systemv=yes
+fi
+case "${with_init_script}" in
+   systemv) init_systemv=yes;;
+   systemd) init_systemd=yes;;
+   check) ;;
+   *) AC_MSG_ERROR([Unknown initscript type $with_init_script]);;
+esac
+AM_CONDITIONAL([INIT_SCRIPT_SYSTEMV], test "$init_systemv" = "yes")
+AM_CONDITIONAL([INIT_SCRIPT_SYSTEMD], test "$init_systemd" = "yes")
+
 AC_OUTPUT(vhostmd/Makefile
           include/Makefile
           libmetrics/Makefile

--- a/vhostmd.service
+++ b/vhostmd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Daemon for collecting virutalization host metrics
+After=libvirtd.service
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/vhostmd
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStop=/bin/kill -TERM $MAINPID
+Documentation=man:vhostmd(8)
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
vhostmd is long overdue for a systemd service file. Add one, and
while at it support specifying the type of init system in the
configure script.

Signed-off-by: Jim Fehlig <jfehlig@suse.com>