### PR TITLE
Modernize build files and add systemd service file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,11 +8,10 @@ EXTRA_DIST = $(doc_DATA) vhostmd.init vhostmd.spec autogen.sh
 AUTOMAKE_OPTIONS=dist-bzip2
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)/etc/vhostmd
-	$(mkinstalldirs) $(DESTDIR)/etc/init.d
-	$(mkinstalldirs) $(DESTDIR)/usr/sbin
-	-@INSTALL@ -m 0644 $(srcdir)/vhostmd.xml $(DESTDIR)/etc/vhostmd/vhostmd.conf
-	-@INSTALL@ -m 0644 $(srcdir)/vhostmd.dtd $(DESTDIR)/etc/vhostmd
-	-@INSTALL@ -m 0644 $(srcdir)/metric.dtd $(DESTDIR)/etc/vhostmd
-	-@INSTALL@ -m 0755 $(srcdir)/vhostmd.init $(DESTDIR)/etc/init.d/vhostmd
-
+	$(MKDIR_P) $(DESTDIR)/etc/vhostmd
+	$(MKDIR_P) $(DESTDIR)/etc/init.d
+	$(MKDIR_P) $(DESTDIR)/usr/sbin
+	$(INSTALL_DATA) $(srcdir)/vhostmd.xml $(DESTDIR)/etc/vhostmd/vhostmd.conf
+	$(INSTALL_DATA) $(srcdir)/vhostmd.dtd $(DESTDIR)/etc/vhostmd
+	$(INSTALL_DATA) $(srcdir)/metric.dtd $(DESTDIR)/etc/vhostmd
+	$(INSTALL_SCRIPT) $(srcdir)/vhostmd.init $(DESTDIR)/etc/init.d/vhostmd

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,11 +7,41 @@ EXTRA_DIST = $(doc_DATA) vhostmd.init vhostmd.spec autogen.sh
 
 AUTOMAKE_OPTIONS=dist-bzip2
 
-install-data-local:
+install-data-local: install-init-systemv install-init-systemd
 	$(MKDIR_P) $(DESTDIR)/etc/vhostmd
-	$(MKDIR_P) $(DESTDIR)/etc/init.d
-	$(MKDIR_P) $(DESTDIR)/usr/sbin
 	$(INSTALL_DATA) $(srcdir)/vhostmd.xml $(DESTDIR)/etc/vhostmd/vhostmd.conf
 	$(INSTALL_DATA) $(srcdir)/vhostmd.dtd $(DESTDIR)/etc/vhostmd
 	$(INSTALL_DATA) $(srcdir)/metric.dtd $(DESTDIR)/etc/vhostmd
+
+uninstall-local: uninstall-init-systemv uninstall-init-systemd
+	rm -f $(DESTDIR)/etc/vhostmd/vhostmd.conf
+	rm -f $(DESTDIR)/etc/vhostmd/vhostmd.dtd
+	rm -f $(DESTDIR)/etc/vhostmd/metric.dtd
+	rmdir $(DESTDIR)/etc/vhostmd || :
+
+if INIT_SCRIPT_SYSTEMV
+install-init-systemv: $(srcdir)/vhostmd.init
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/init.d
 	$(INSTALL_SCRIPT) $(srcdir)/vhostmd.init $(DESTDIR)/etc/init.d/vhostmd
+
+uninstall-init-systemv:
+	rm -f $(DESTDIR)$(sysconfdir)/init.d/vhostmd
+	rmdir $(DESTDIR)$(sysconfdir)/init.d || :
+else ! INIT_SCRIPT_SYSTEMV
+install-init-systemv:
+uninstall-init-systemv:
+endif ! INIT_SCRIPT_SYSTEMV
+
+if INIT_SCRIPT_SYSTEMD
+SYSTEMD_UNIT_DIR = $(prefix)/lib/systemd/system
+install-init-systemd: $(srcdir)/vhostmd.service
+	$(MKDIR_P) $(DESTDIR)$(SYSTEMD_UNIT_DIR)
+	$(INSTALL_DATA) $(srcdir)/vhostmd.service $(DESTDIR)$(SYSTEMD_UNIT_DIR)/vhostmd.service
+
+uninstall-init-systemd:
+	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/vhostmd.service
+	rmdir $(DESTDIR)$(SYSTEMD_UNIT_DIR) || :
+else ! INIT_SCRIPT_SYSTEMD
+install-init-systemd:
+uninstall-init-systemd:
+endif ! INIT_SCRIPT_SYSTEMD

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(Virtual Host Metrics Daemon, 0.5, jfehlig@novell.com, vhostmd)
+AC_INIT(Virtual Host Metrics Daemon, 0.5, jfehlig@suse.com, vhostmd)
 
 AC_CONFIG_SRCDIR(vhostmd/vhostmd.c)
 AC_CONFIG_HEADERS([config.h])
@@ -81,6 +81,28 @@ AC_ARG_WITH([xenstore],
    *) AC_MSG_ERROR(bad value ${withval} for --with-xenstore) ;;
   esac],[AC_CHECK_HEADER(xs.h, with_xenstore=true)])
 AM_CONDITIONAL(WITH_XENSTORE, test x$with_xenstore = xtrue)
+
+# Configure argument to support type of init system
+AC_ARG_WITH([init_script],
+  [AS_HELP_STRING([--with-init-script],
+    [Type of init script to install: systemv, systemd, check @<:@default=check@:>@])],
+  [],
+  [with_init_script=check])
+init_systemv=no
+init_systemd=no
+if test "$with_init_script" = check && type systemctl >/dev/null 2>&1; then
+   init_systemd=yes
+else
+   init_systemv=yes
+fi
+case "${with_init_script}" in
+   systemv) init_systemv=yes;;
+   systemd) init_systemd=yes;;
+   check) ;;
+   *) AC_MSG_ERROR([Unknown initscript type $with_init_script]);;
+esac
+AM_CONDITIONAL([INIT_SCRIPT_SYSTEMV], test "$init_systemv" = "yes")
+AM_CONDITIONAL([INIT_SCRIPT_SYSTEMD], test "$init_systemd" = "yes")
 
 AC_OUTPUT(vhostmd/Makefile
           include/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@ AC_CONFIG_SRCDIR(vhostmd/vhostmd.c)
 AC_CONFIG_HEADERS([config.h])
 
 AC_GNU_SOURCE
+AM_INIT_AUTOMAKE
 
 AC_PROG_LIBTOOL
 
@@ -21,7 +22,6 @@ AC_SUBST(topdir)
 
 AC_CONFIG_FILES([Makefile])
 
-AM_INIT_AUTOMAKE
 
 # Checks for programs.
 AM_PROG_CC_C_O

--- a/vhostmd.service
+++ b/vhostmd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Daemon for collecting virutalization host metrics
+After=libvirtd.service
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/vhostmd
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStop=/bin/kill -TERM $MAINPID
+Documentation=man:vhostmd(8)
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Some of the constructs used in the configure script and Makefiles are a bit outdated, e.g. use of '$(mkinstalldirs)' instead of '$(MKDIR_P)'. Change these old constructs to their modern counterparts.

Also add a systemd service file for vhostmd.