### PR TITLE
Add a 'unit' attribute to the metrics element

### DIFF
--- a/docs/man/vhostmd.8
+++ b/docs/man/vhostmd.8
@@ -129,14 +129,15 @@ metrics to be collected.  This can be extended or modified by editing
 /etc/vhostmd/vhostmd.conf and changing existing metric definitions or
 adding new metric definitions under the metrics container.
 
-Defined metrics begin with the <metric> element, which contains two
-attributes: type and context.  The type attribute is used to describe the
-metric's value type.  Supported types are int32, uint32, int64, uint64,
+Defined metrics begin with the <metric> element, which contains three
+attributes: type, context, and unit.  The type attribute is used to describe
+the metric's value type.  Supported types are int32, uint32, int64, uint64,
 real32, real64, string, group, and xml. group is used when an action returns
 more than one metric value. xml is the most flexible type and specifies that
 the metric's action returns valid metric XML.  The context attribute is used
 to indicate whether this is a host or vm metric.  Supported contexts are
-host and vm.
+host and vm. The optional unit attribute describes the unit of measure
+produced for the metric by the defined action.
 
 Currently, the metric element contains 3 elements: name, action, and variable.
 The name element defines the metric's name.  The action element describes a

--- a/include/metric.h
+++ b/include/metric.h
@@ -51,6 +51,7 @@ typedef struct _metric {
    char *action;
    char *type_str;
    int cnt;
+   char *unit;
    metric_context ctx;
    metric_type type;
    metric_func pf;

--- a/mdisk.xml
+++ b/mdisk.xml
@@ -35,7 +35,7 @@ context attribute specifies whether the metric is host or vm.
       <name>TotalPhyMem</name>
       <value>8124</value>
     </metric>
-    <metric type="uint64" context="host">
+    <metric type="uint64" context="host" unit="MiB">
       <name>FreePhyMem</name>
       <value>8124</value>
     </metric>
@@ -43,7 +43,7 @@ context attribute specifies whether the metric is host or vm.
       <name>NumCPUsUtilized</name>
       <value>16</value>
     </metric>
-    <metric type="real64" context="vm" id="0">
+    <metric type="real64" context="vm" id="0" unit="s">
       <name>TotalCPUTime</name>
       <value>1234.567</value>
     </metric>
@@ -55,7 +55,7 @@ context attribute specifies whether the metric is host or vm.
       <name>NumCPUsUtilized</name>
       <value>16</value>
     </metric>
-    <metric type="real64" context="vm" id="2">
+    <metric type="real64" context="vm" id="2" unit="s">
       <name>TotalCPUTime</name>
       <value>1234.567</value>
     </metric>

--- a/metric.dtd
+++ b/metric.dtd
@@ -15,6 +15,7 @@ Metric DTD
           context (host|vm) #REQUIRED
           id CDATA #IMPLIED
           uuid CDATA #IMPLIED
+          unit CDATA #IMPLIED
 >
 <!ELEMENT name (#PCDATA)>
 <!ELEMENT value (#PCDATA)>

--- a/vhostmd.dtd
+++ b/vhostmd.dtd
@@ -31,6 +31,7 @@ Virtual Host Metrics Daemon (vhostmd). Configuration file DTD
           type (xml|group|int32|uint32|int64|uint64|real32|real64|string) #REQUIRED
           context (host|vm) #REQUIRED
           cnt CDATA #IMPLIED
+          unit CDATA #IMPLIED
 >
 <!ELEMENT variable (#PCDATA)>
 <!ATTLIST variable 

--- a/vhostmd.xml
+++ b/vhostmd.xml
@@ -77,7 +77,7 @@ the logical && operator must be replaced with "&amp;&amp;".
           virsh nodeinfo | awk '/^CPU\(s\)/ {print $2}'
         </action>
       </metric>
-      <metric type="uint64" context="host">
+      <metric type="uint64" context="host" unit="MiB">
         <name>TotalPhyMem</name>
         <action>
           echo $((`virsh nodeinfo | awk '/^Memory/ {print $3}'` / 1024))
@@ -115,7 +115,7 @@ the logical && operator must be replaced with "&amp;&amp;".
         <variable name="PageInRate" type="uint64"/>
         <variable name="PageFaultRate" type="uint64"/>
       </metric>
-      <metric type="real64" context="host">
+      <metric type="real64" context="host" unit="s">
         <name>TotalCPUTime</name>
         <action>
           [ -f /proc/xen/privcmd ] &amp;&amp; xl list | awk '/^Domain-0/ {print $6}' || \
@@ -150,7 +150,7 @@ the logical && operator must be replaced with "&amp;&amp;".
           }'
         </action>
       </metric>
-      <metric type="real64" context="vm">
+      <metric type="real64" context="vm" unit="s">
         <name>TotalCPUTime</name>
         <action>
           virsh CONNECT dominfo NAME | sed 's/: */:/' | \

--- a/vhostmd/metric.c
+++ b/vhostmd/metric.c
@@ -292,6 +292,7 @@ int metric_xml(metric *m, vu_buffer *buf)
    char *n;
    char *v;
    char *t;
+   char *u;
    int i;
 
    if (metric_value_get(m))
@@ -312,28 +313,35 @@ int metric_xml(metric *m, vu_buffer *buf)
        n = vu_get_nth_token(m->name, ",", i, m->cnt); 
        t = vu_get_nth_token(m->type_str, ",", i, m->cnt);
        v = vu_get_nth_token(m->value, ",", i, m->cnt);
+       u = vu_get_nth_token(m->unit, ",", i, m->cnt);
        
-	   if (m->ctx == METRIC_CONTEXT_HOST) {
-		   vu_buffer_vsprintf(buf,
-				   "  <metric type='%s' context='host'>\n"
-				   "    <name>%s</name>\n"
-				   "    <value>%s</value>\n"
-				   "  </metric>\n",
-				   t,
-				   n,
-				   v);
+       if (m->ctx == METRIC_CONTEXT_HOST) {
+		   vu_buffer_vsprintf(buf, "  <metric type='%s' context='host'", t);
+           if (u && u[0] != '\0')
+               vu_buffer_vsprintf(buf, " unit='%s'", u);
+           vu_buffer_add(buf, ">\n", 3);
+           vu_buffer_vsprintf(buf,
+                              "    <name>%s</name>\n"
+                              "    <value>%s</value>\n"
+                              "  </metric>\n",
+                              n,
+                              v);
 	   }
 	   else {
 		   vu_buffer_vsprintf(buf,
-				   "  <metric type='%s' context='vm' id='%d' uuid='%s'>\n"
-				   "    <name>%s</name>\n"
-				   "    <value>%s</value>\n"
-				   "  </metric>\n",
-				   t,
-				   m->vm->id,
-				   m->vm->uuid,
-				   n,
-				   v);
+                              "  <metric type='%s' context='vm' id='%d' uuid='%s'",
+                              t,
+                              m->vm->id,
+                              m->vm->uuid);
+           if (u && u[0] != '\0')
+               vu_buffer_vsprintf(buf, " unit='%s'", u);
+           vu_buffer_add(buf, ">\n", 3);
+           vu_buffer_vsprintf(buf,
+                              "    <name>%s</name>\n"
+                              "    <value>%s</value>\n"
+                              "  </metric>\n",
+                              n,
+                              v);
 	   }
 	   if (n) free(n);
 	   if (t) free(t);

--- a/vhostmd/vhostmd.c
+++ b/vhostmd/vhostmd.c
@@ -285,6 +285,11 @@ static int parse_group_metric(xmlDocPtr xml ATTRIBUTE_UNUSED,
       }
       vu_append_string(&mdef->type_str, prop);
       free(prop);
+
+      if ((prop = xmlGetProp(n, BAD_CAST "unit"))) {
+          vu_append_string(&mdef->unit, prop);
+          free(prop);
+      }
    }
    ret = 0;
 error:
@@ -302,6 +307,7 @@ static metric *parse_metric(xmlDocPtr xml, xmlXPathContextPtr ctxt, xmlNodePtr n
    xmlNodePtr cur;
    xmlChar *mtype = NULL;
    xmlChar *mcontext = NULL;
+   xmlChar *munit = NULL;
    xmlChar *str;
 
    mdef = calloc(1, sizeof(metric));
@@ -337,7 +343,12 @@ static metric *parse_metric(xmlDocPtr xml, xmlXPathContextPtr ctxt, xmlNodePtr n
                   "supported contexts (host) and (vm)", mcontext);
       goto error;
    }
-      
+
+   /* Get the metric unit attribute */
+   if ((munit = xmlGetProp(node, BAD_CAST "unit"))) {
+       mdef->unit = strdup((char *)munit);
+   }
+
    /* Get the metric name and the action */
    cur = node->xmlChildrenNode;
 
@@ -377,6 +388,7 @@ static metric *parse_metric(xmlDocPtr xml, xmlXPathContextPtr ctxt, xmlNodePtr n
 
    free(mtype);
    free(mcontext);
+   free(munit);
 
    return mdef;
    
@@ -389,6 +401,7 @@ static metric *parse_metric(xmlDocPtr xml, xmlXPathContextPtr ctxt, xmlNodePtr n
    }
    free(mtype);
    free(mcontext);
+   free(munit);
    
    return NULL;
 }


### PR DESCRIPTION
Add an optional 'unit' attribute to the <metrics> element. The
value of 'unit' provided in a <metric> definition is opaque to vhostmd
and returned as is when reporting the metric value.

Fixes: https://github.com/vhostmd/vhostmd/issues/8

Signed-off-by: Jim Fehlig <jfehlig@suse.com>