### PR TITLE
Change actions to retrieve vendor and product info

### DIFF
--- a/vhostmd.xml
+++ b/vhostmd.xml
@@ -53,16 +53,13 @@ the logical && operator must be replaced with "&amp;&amp;".
       <metric type="string" context="host">
         <name>VirtualizationVendor</name>
         <action>
-          [ -f /proc/xen/privcmd ] &amp;&amp; RPM="xen" || RPM="libvirt"; \
-          rpm -q --queryformat "%{VENDOR}\n" $RPM | sort -u | sed -e 's/&lt;.*//' -e 's/ *$//'
+	  rpm -q --qf '%{VENDOR}\n' -qf /etc/os-release
         </action>
       </metric>
       <metric type="string" context="host">
         <name>VirtualizationProductInfo</name>
         <action>
-          [ -f /proc/xen/privcmd ] &amp;&amp; xl info | \
-          awk '/^xen_(major|minor|extra)/ {print $3}' | sed -e 'N;s/\n/./' -e 'N;s/\n//' || \
-          rpm -q --queryformat "%{VERSION}-%{RELEASE}\n" libvirt | sort -u
+	  virsh version | awk '/Running hypervisor/ {print $(NF-1),$NF}'
         </action>
       </metric>
       <metric type="uint32" context="host">


### PR DESCRIPTION
On a KVM host, the action to report VirtualizationVendor checks the vendor of the libvirt RPM, which is typically a meta-package that pulls in all of libvirt. This is undesirable on a minimalistic hypervisor. Change the action to check the vendor of the package owning /etc/os-release, which should be available on even the most minimal systems and works for both Xen and KVM.

The VirtualizationProductInfo action reports inconsistent information between Xen and KVM. On a Xen host the Xen version is reported, whereas the libvirt version is reported on a KVM host. Change the action to report the "Running hypervisor" as reported by 'virsh version'.

Fixes: https://github.com/vhostmd/vhostmd/issues/7