### PR TITLE
Fix implicit declarations

### DIFF
--- a/libmetrics/libmetrics.c
+++ b/libmetrics/libmetrics.c
@@ -21,6 +21,7 @@
 #include <config.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/vhostmd/virt-util.c
+++ b/vhostmd/virt-util.c
@@ -21,6 +21,7 @@
 #include <config.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <libvirt/libvirt.h>
 

--- a/vhostmd/virtio.c
+++ b/vhostmd/virtio.c
@@ -30,6 +30,7 @@
 #include <search.h>
 #include <dirent.h>
 #include <pthread.h>
+#include <stdlib.h>
 #include <libvirt/libvirt.h>
 
 #include "util.h"


### PR DESCRIPTION
Errors raised in Fedora rawhide and ELN which have added the -Werror=implicit-function-declaration flag for C:

virt-util.c:96:9: error: implicit declaration of function ‘calloc’
virt-util.c:129:10: error: implicit declaration of function ‘free’

virtio.c:160:9: error: implicit declaration of function ‘free’
virtio.c:254:31: error: implicit declaration of function ‘bsearch’
virtio.c:259:13: error: implicit declaration of function ‘qsort’
virtio.c:586:33: error: implicit declaration of function ‘calloc’

libmetrics.c:136:28: error: implicit declaration of function 'atoi'
libmetrics.c:142:29: error: implicit declaration of function 'atoll'
libmetrics.c:148:28: error: implicit declaration of function 'atof'
libmetrics.c:170:12: error: implicit declaration of function 'calloc'
libmetrics.c:189:12: error: implicit declaration of function 'free'
libmetrics.c:311:7: error: implicit declaration of function 'posix_memalign'
libmetrics.c:385:26: error: implicit declaration of function 'malloc'
libmetrics.c:848:28: error: implicit declaration of function 'realloc'